### PR TITLE
Verbnet 3.3 fixes

### DIFF
--- a/src/main/java/edu/mit/jverbnet/data/syntax/SyntaxArgType.java
+++ b/src/main/java/edu/mit/jverbnet/data/syntax/SyntaxArgType.java
@@ -1,10 +1,10 @@
 /***************************************************************************
  * JVerbnet v1.2.0
  * Copyright (c) 2012 Massachusetts Institute of Technology
- * 
- * JVerbnet is distributed under the terms of the Creative Commons 
- * Attribution 3.0 Unported License, which means it may be freely used for 
- * all purposes, as long as proper acknowledgment is made.  See the license 
+ *
+ * JVerbnet is distributed under the terms of the Creative Commons
+ * Attribution 3.0 Unported License, which means it may be freely used for
+ * all purposes, as long as proper acknowledgment is made.  See the license
  * file included with this distribution for more details.
  ****************************************************************************/
 
@@ -25,34 +25,34 @@ import edu.mit.jverbnet.data.VerbnetTypes;
  * Syntactic argument types. The values in this enum correspond to the named
  * elements of xsd:choice subelement of the SYNTAX portion of the Verbnet xsd
  * file.
- * 
+ *
  * @author Mark A. Finlayson
  * @version 1.2.0
  * @since JVerbnet 1.0.0
  */
 public enum SyntaxArgType implements IVerbnetType {
-	
+
 	NP  ("NP",   "Noun Phrase", VALUE_RULE.REQUIRED),
-	ADV ("ADV",  "Adverb",      VALUE_RULE.PROHIBITED),
+	ADV ("ADV",  "Adverb",      VALUE_RULE.OPTIONAL),
 	ADJ ("ADJ",  "Adjective",   VALUE_RULE.PROHIBITED),
 	PREP("PREP", "Preposition", VALUE_RULE.OPTIONAL),
 	LEX ("LEX",  "Lexical",     VALUE_RULE.REQUIRED);
-	
-	/** 
+
+	/**
 	 * The name of the xsd:simpleType entry that describes this verbnet type in the XSD file.
 	 *
 	 * @since JVerbnet 1.0.0
 	 */
 	public static final String XSD_TYPE_NAME = "argType";
-	
+
 	// final fields
 	private final String id;
 	private final String name;
 	private final VALUE_RULE vRule;
-	
+
 	/**
 	 * Enum constructor that creates a new event argument type.
-	 * 
+	 *
 	 * @param name
 	 *            The human-readable name of the type.
 	 * @since JVerbnet 1.0.0
@@ -66,26 +66,26 @@ public enum SyntaxArgType implements IVerbnetType {
 		id = NotNullEmptyOrBlank.check("id", id);
 		name = NotNullEmptyOrBlank.check("name", name);
 		NotNull.check("vRule", vRule);
-		
+
 		// assign fields
 		this.id = id;
 		this.name = name;
 		this.vRule = vRule;
 	}
-	
-	/* 
-	 * (non-Javadoc) 
+
+	/*
+	 * (non-Javadoc)
 	 *
 	 * @see edu.mit.jverbnet.data.IVerbnetType#getID()
 	 */
 	public String getID(){
 		return id;
 	}
-	
+
 	/**
 	 * Returns a human-readable name for this argument type, suitable for
 	 * display in a UI.
-	 * 
+	 *
 	 * @return a human-readable name for this argument type, suitable for
 	 *         display in a UI.
 	 * @since JVerbnet 1.0.0
@@ -93,30 +93,30 @@ public enum SyntaxArgType implements IVerbnetType {
 	public String getName(){
 		return name;
 	}
-	
+
 	/**
 	 * Returns the value rule for this argument type.
-	 * 
+	 *
 	 * @return the non-<code>null</code> value rule for this type
 	 * @since JVerbnet 1.0.0
 	 */
 	public VALUE_RULE getValueRule(){
 		return vRule;
 	}
-	
+
 	// the id map for the getById method
 	private static Map<String, SyntaxArgType> idMap;
-	
+
 	/**
 	 * Returns the object corresponding to the specified xsd name. The id is
 	 * matched to values without regard to case. If no value has the specified
 	 * id, the method returns null.
-	 * 
+	 *
 	 * If the {@link VerbnetTypes#isPrintingIdWarnings()} flag is set, the method
 	 * will print a warning to standard out if there is no value with the
 	 * specified id, or if the specified id is not exactly identical to the
 	 * value's id (i.e., differs in case).
-	 * 
+	 *
 	 * @param id
 	 *            the id of the type value as found in the xsd file and in the
 	 *            xml data files.
@@ -134,7 +134,7 @@ public enum SyntaxArgType implements IVerbnetType {
 		VerbnetTypes.printIdWarnings(AuxNounPhraseType.class, result, id);
 		return result;
 	}
-	
+
 	// the following code initializes the id map
 	static {
 		SyntaxArgType[] values = values();
@@ -146,8 +146,8 @@ public enum SyntaxArgType implements IVerbnetType {
 				throw new IllegalStateException("The constants " + t.name() + " and " + conflict.name() + " of the enum " + SyntaxArgType.class.getSimpleName() + " have identical normalized ids: " + t.getID().toLowerCase());
 		}
 	}
-	
-	/** 
+
+	/**
 	 * Checks that the value meets the expectations of the type.
 	 *
 	 * @author Mark A. Finlayson
@@ -155,8 +155,8 @@ public enum SyntaxArgType implements IVerbnetType {
 	 * @since JVerbnet 1.0.0
 	 */
 	public enum VALUE_RULE {
-		
-		/** 
+
+		/**
 		 * The value must be <code>null</code>.
 		 *
 		 * @since JVerbnet 1.0.0
@@ -168,8 +168,8 @@ public enum SyntaxArgType implements IVerbnetType {
 				return null;
 			}
 		},
-		
-		/** 
+
+		/**
 		 * The value may be anything.
 		 *
 		 * @since JVerbnet 1.0.0
@@ -180,8 +180,8 @@ public enum SyntaxArgType implements IVerbnetType {
 				return trim(NotNull, value);
 			}
 		},
-		
-		/** 
+
+		/**
 		 * The value must not be <code>null</code>, empty, or blank.
 		 *
 		 * @since JVerbnet 1.0.0
@@ -192,10 +192,10 @@ public enum SyntaxArgType implements IVerbnetType {
 				return NotNullEmptyOrBlank.check("value", value);
 			}
 		};
-		
+
 		/**
 		 * Checks that the string value meets the condition.
-		 * 
+		 *
 		 * @param value
 		 *            the value to be checked
 		 * @throws Exception
@@ -206,5 +206,5 @@ public enum SyntaxArgType implements IVerbnetType {
 		 */
 		public abstract String checkValue(String value);
 	}
-	
+
 }

--- a/src/main/java/edu/mit/jverbnet/parse/FrameHandler.java
+++ b/src/main/java/edu/mit/jverbnet/parse/FrameHandler.java
@@ -1,10 +1,10 @@
 /***************************************************************************
  * JVerbnet v1.2.0
  * Copyright (c) 2012 Massachusetts Institute of Technology
- * 
- * JVerbnet is distributed under the terms of the Creative Commons 
- * Attribution 3.0 Unported License, which means it may be freely used for 
- * all purposes, as long as proper acknowledgment is made.  See the license 
+ *
+ * JVerbnet is distributed under the terms of the Creative Commons
+ * Attribution 3.0 Unported License, which means it may be freely used for
+ * all purposes, as long as proper acknowledgment is made.  See the license
  * file included with this distribution for more details.
  ****************************************************************************/
 
@@ -26,7 +26,7 @@ import edu.mit.jverbnet.util.parse.IHasParserHandler;
 import edu.mit.jverbnet.util.parse.ListHandler;
 import edu.mit.jverbnet.util.parse.MappedHandler;
 
-/** 
+/**
  * Handles Verbnet XML blocks tagged with {@value #XML_TAG_FRAME}.
  *
  * @author Mark A. Finlayson
@@ -34,16 +34,16 @@ import edu.mit.jverbnet.util.parse.MappedHandler;
  * @since JVerbnet 1.0.0
  */
 public class FrameHandler extends MappedHandler<FrameBuilder> {
-	
+
 	public static final String XML_TAG_FRAMES = "FRAMES";
 	public static final String XML_TAG_FRAME = "FRAME";
 	public static final String XML_TAG_DESCRIPTION = "DESCRIPTION";
 	public static final String XML_TAG_EXAMPLES = "EXAMPLES";
 	public static final String XML_TAG_EXAMPLE = "EXAMPLE";
-	
+
 	// the handler for the examples list element
 	private final ListHandler<String> examplesHandler = new ListHandler<String>(this, XML_TAG_EXAMPLES, new CDataHandler(XML_TAG_EXAMPLE));
-	
+
 	// assignable fields
 	private String descNum;
 	private FrameType primaryType;
@@ -52,9 +52,9 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 	private ISyntaxDesc syntaxDesc;
 	private ISemanticDesc semanticDesc;
 
-	/** 
+	/**
 	 * Creates a new FrameHandler with no parent or parser.
-	 * 
+	 *
 	 * @since JVerbnet 1.0.0
 	 */
 	public FrameHandler() {
@@ -63,7 +63,7 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 
 	/**
 	 * Creates a new FrameHandler with the specified parent.
-	 * 
+	 *
 	 * @param parent
 	 *            the parent of the handler; may be <code>null</code>
 	 * @since JVerbnet 1.0.0
@@ -71,10 +71,10 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 	public FrameHandler(IHasParserHandler parent) {
 		this((parent == null ? null : parent.getParser()), parent);
 	}
-	
+
 	/**
 	 * Creates a new FrameHandler with the specified parser.
-	 * 
+	 *
 	 * @param parser
 	 *            the parser of the handler; may be <code>null</code>
 	 * @since JVerbnet 1.0.0
@@ -82,10 +82,10 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 	public FrameHandler(XMLReader parser) {
 		this(parser, null);
 	}
-	
+
 	/**
 	 * Creates a new FrameHandler with the specified parser and parent.
-	 * 
+	 *
 	 * @param parser
 	 *            the parent of the handler; may be <code>null</code>
 	 * @param parent
@@ -96,14 +96,14 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 		super(parser, parent, XML_TAG_FRAME);
 	}
 
-	/* 
-	 * (non-Javadoc) 
+	/*
+	 * (non-Javadoc)
 	 *
 	 * @see edu.mit.jverbnet.util.parse.MappedHandler#initHandlerMap(java.util.Map)
 	 */
 	@Override
 	protected void initHandlerMap(Map<String, ContentHandler> map) {
-		
+
 		MappedHandler<Object> descHandler = new MappedHandler<Object>(this, XML_TAG_DESCRIPTION) {
 			@Override
 			public void startTaggedBlock(String uri, String localName, String qName, Attributes attrs) throws SAXException {
@@ -111,10 +111,10 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 				String primaryTypeStr = attrs.getValue("primary");
 				String secondaryTypeStr = attrs.getValue("secondary");
 				xTag = attrs.getValue("xtag");
-				
+
 				// get types
 				primaryType = FrameType.getById(primaryTypeStr);
-				if(secondaryTypeStr.length() != 0)
+				if(secondardTypeStr != null && secondaryTypeStr.length() != 0)
 					secondaryType = FrameType.getById(secondaryTypeStr);
 			}
 		};
@@ -125,14 +125,14 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 				syntaxDesc = doGetElement();
 			}
 		};
-		
+
 		SemanticDescHandler semanticsHandler = new SemanticDescHandler(this){
 			@Override
 			public void endTaggedBlock(String uri, String localName, String qName) throws SAXException {
 				semanticDesc = doGetElement();
 			}
 		};
-		
+
 		// assign handlers
 		map.put(descHandler.getTag(), descHandler);
 		map.put(examplesHandler.getTag(), examplesHandler);
@@ -140,8 +140,8 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 		map.put(semanticsHandler.getTag(), semanticsHandler);
 	}
 
-	/* 
-	 * (non-Javadoc) 
+	/*
+	 * (non-Javadoc)
 	 *
 	 * @see edu.mit.jverbnet.util.parse.MappedHandler#clearLocal()
 	 */
@@ -154,9 +154,9 @@ public class FrameHandler extends MappedHandler<FrameBuilder> {
 		syntaxDesc = null;
 		semanticDesc = null;
 	}
-	
-	/* 
-	 * (non-Javadoc) 
+
+	/*
+	 * (non-Javadoc)
 	 *
 	 * @see edu.mit.jverbnet.util.parse.MappedHandler#doGetElement()
 	 */


### PR DESCRIPTION
Have emailed to markaf@fiu.edu as well.

modified: edu/mit/jverbnet/data/syntax/SyntaxArgType.java
Make adverb value rule optional
Fixes:
Parsing problem: rotate-51.9.1.xml (version 3.3)
java.lang.IllegalArgumentException: value must be null

modified:   edu/mit/jverbnet/parse/FrameHandler.java
Check for null on secondaryTypeStr
Fixes:
Parsing problem: attack-60.1.xml (version 3.3)
java.lang.NullPointerException

Test output:
13:56:16.248 [main] INFO edu.mit.jverbnet.UnitTest:29 - verbnet31: 5032
13:56:16.507 [main] INFO  edu.mit.jverbnet.UnitTest:30 - verbnet32: 5359
13:56:16.778 [main] INFO  edu.mit.jverbnet.UnitTest:31 - verbnet33: 5377